### PR TITLE
chore: update GitHub Actions to use main branch instead of master

### DIFF
--- a/.github/workflows/docker-image-production.yml
+++ b/.github/workflows/docker-image-production.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: log in to docker hub
         uses: docker/login-action@v3
@@ -48,10 +48,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: deploy stage
-        uses: alinz/ssh-scp-action@master
+        uses: alinz/ssh-scp-action@main
         with:
           key: ${{ secrets.DEPLOY_KEY }}
           host: ${{ secrets.APP_HOST }}

--- a/.github/workflows/docker-image-stage.yml
+++ b/.github/workflows/docker-image-stage.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: log in to docker hub
         uses: docker/login-action@v3
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check out the repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
 
       - name: deploy stage
-        uses: alinz/ssh-scp-action@master
+        uses: alinz/ssh-scp-action@main
         with:
           key: ${{ secrets.DEPLOY_KEY }}
           host: ${{ secrets.APP_HOST }}


### PR DESCRIPTION
## Summary

- Replaced `@master` action pins with `@main` in both workflow files
- Affects `actions/checkout` and `alinz/ssh-scp-action` references

## Why

The repo's default branch was renamed from `master` to `main`. The workflow files were still referencing `@master` on external actions.

## Reviewer notes

`alinz/ssh-scp-action` should be verified to have a `main` branch — if it doesn't, the deploy step will fail. Consider pinning to a commit SHA or version tag for stability.